### PR TITLE
[release 2.1] Remediate Package Vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ curl -L https://github.com/operator-framework/operator-sdk/releases/download/v0.
 - `go mod vendor`
 - `operator-sdk build <repo>/<component>:<tag>` for example: quay.io/open-cluster-management/search-operator:v0.1.0.
 - Replace the image in `deploy/operator.yaml`.
-- Update your namespace in `deploy/role_binding.yaml`
+- Update your namespace in `deploy/role_binding.yaml`.


### PR DESCRIPTION
Issue: open-cluster-management/backlog#6838

Added a change to README so that image will rebuild in order to fix vulnerabilities in image scan. Also merging this branch into release-2.1 so that fix can be picked up in release 2.1.1 zstream