### PR TITLE
Revert " added fsgroup and runasgroup to get write access to pvc (#25)"

### DIFF
--- a/config/samples/search.open-cluster-management.io_v1_searchoperator.yaml
+++ b/config/samples/search.open-cluster-management.io_v1_searchoperator.yaml
@@ -13,6 +13,6 @@ spec:
   pullpolicy: Always
   pullsecret: multiclusterhub-operator-pull-secret
   searchimageoverrides:
-    redisgraph_tls: quay.io/open-cluster-management/redisgraph-tls:2.2.0-PR34-9d19a44994a8da25f212ddcf410b8ac588838b97
+    redisgraph_tls: quay.io/open-cluster-management/redisgraph-tls:2.2.0-PR30-338256dd6806b528e39a76552379da9c3f939b9a
   storagesize: 10Gi
 

--- a/controllers/searchoperator_controller.go
+++ b/controllers/searchoperator_controller.go
@@ -48,7 +48,6 @@ const (
 	statusFailedDegraded      = "Unable to create Redisgraph Deployment in Degraded Mode"
 	statusFailedUsingPVC      = "Unable to create Redisgraph Deployment using PVC"
 	statusFailedNoPersistence = "Unable to create Redisgraph Deployment"
-	redisUser                 = int64(10001)
 )
 
 var (
@@ -183,8 +182,6 @@ func (r *SearchOperatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func int32Ptr(i int32) *int32 { return &i }
 
-func int64Ptr(i int64) *int64 { return &i }
-
 func getStatefulSet(cr *searchv1alpha1.SearchOperator, rdbVolumeSource v1.VolumeSource) *appv1.StatefulSet {
 	bool := false
 	return &appv1.StatefulSet{
@@ -192,8 +189,7 @@ func getStatefulSet(cr *searchv1alpha1.SearchOperator, rdbVolumeSource v1.Volume
 			Name:      statefulSetName,
 			Namespace: cr.Namespace,
 			Annotations: map[string]string{
-				"owner":            "search-operator",
-				"openshift.io/scc": "anyuid",
+				"owner": "search-operator",
 			},
 		},
 		Spec: appv1.StatefulSetSpec{
@@ -216,10 +212,6 @@ func getStatefulSet(cr *searchv1alpha1.SearchOperator, rdbVolumeSource v1.Volume
 					ImagePullSecrets: []v1.LocalObjectReference{{
 						Name: cr.Spec.PullSecret,
 					}},
-					SecurityContext: &v1.PodSecurityContext{
-						FSGroup:    int64Ptr(redisUser),
-						RunAsUser: int64Ptr(redisUser),
-					},
 					Containers: []v1.Container{
 						{
 							Name:  "redisgraph",


### PR DESCRIPTION
This reverts commit 7c0a1373520e4a2f2bd6e0e4f93b1ac7a8524955.

Issue: https://github.com/open-cluster-management/backlog/issues/7970