### PR TITLE
updated default addon limit memory

### DIFF
--- a/addon/manifests/chart/values.yaml
+++ b/addon/manifests/chart/values.yaml
@@ -23,7 +23,7 @@ resources:
   requests:
     memory: 128Mi
   limits:
-    memory: 512Mi
+    memory: 1024Mi
 
 logLevel: null
 


### PR DESCRIPTION
Signed-off-by: Xavier Dharmaiyan <xavier@redhat.com>

**Related Issue:**  https://github.com/stolostron/backlog/issues/18606

### Description of changes
- Update memory limit of collector in managed cluster to 1Gi
